### PR TITLE
Fix for emails with multiple <html> tags.

### DIFF
--- a/src/email_to_soup/main.py
+++ b/src/email_to_soup/main.py
@@ -31,6 +31,11 @@ def soupify_email(email: str) -> EmailSoup:
     """
     email = Parser(policy=default_policy).parsestr(email)
     html_body = email.get_body(preferencelist=('html', 'plain')).get_content()
+
+    # Oh, the wonders of HTML emails. Some emails have multiple <html> tags. Let's the one with more content.
+    if html_body:
+        html_body = max(re.findall(r"<html .*?</html>", html_body, re.M|re.S|re.I), key=len)
+
     html_soup = BeautifulSoup(html_body, features="lxml")
     xml_tree = html.fromstring(html_body)
     email_soup = EmailSoup(


### PR DESCRIPTION
Found that some emails sported multiple <html> tags and `html_soup = BeautifulSoup(html_body, features="lxml")` would return empty string in such cases. 

This PR will select the longest `html` section to feed to bs4.